### PR TITLE
Configurable myshopify domain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,26 @@
-source 'https://rubygems.org'
-ruby '2.1.5'
+source "https://rubygems.org"
+ruby "2.1.5"
 
 gem "rails", "4.2.0"
 
-gem 'shopify_app'
-gem 'jquery-rails'
-gem 'quiet_assets'
+gem "shopify_app", "~> 5.0.2"
+gem "jquery-rails"
+gem "quiet_assets"
 
 group :assets do
-  gem 'sass-rails'
-  gem 'coffee-rails'
-  gem 'uglifier', '>= 1.0.3'
+  gem "sass-rails"
+  gem "coffee-rails"
+  gem "uglifier", ">= 1.0.3"
 end
 
 group :development, :test do
-  gem 'thin'
+  gem "thin"
   gem "less-rails-bootstrap"
-  gem "therubyracer", :platforms => :ruby
-  gem 'pry-rails'
-  gem 'sqlite3'
+  gem "therubyracer", platforms: :ruby
+  gem "pry-rails"
+  gem "sqlite3"
 end
 
 group :production do
-  gem 'pg'
+  gem "pg"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     shopify_api (3.2.1)
       activeresource (>= 3.0.0)
       thor (>= 0.14.4)
-    shopify_app (5.0.1)
+    shopify_app (5.0.2)
       less-rails-bootstrap (~> 2.0)
       omniauth-shopify-oauth2 (~> 1.1.4)
       rails (>= 3.1, < 5.0)
@@ -199,7 +199,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.0)
   sass-rails
-  shopify_app
+  shopify_app (~> 5.0.2)
   sqlite3
   therubyracer
   thin

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
 
   def sanitize_shop_param(params)
     return unless params[:shop].present?
-    return unless domain = Rails.configuration.shopify_domain
+    return unless domain = ShopifyApp.configuration.myshopify_domain || "myshopify.com"
 
     name = params[:shop].to_s.strip
     name += ".#{domain}" if !name.include?(domain) && !name.include?(".")

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,6 @@ module EmbededApp
     config.assets.version = '1.0'
 
     # Shopify Domain
-    config.shopify_domain = "myshopify.com"
+    config.shopify_domain = ShopifyApp.configuration.myshopify_domain || "myshopify.com"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,8 +55,5 @@ module EmbededApp
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
-
-    # Shopify Domain
-    config.shopify_domain = ShopifyApp.configuration.myshopify_domain || "myshopify.com"
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,14 +1,14 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :shopify, 
-           ShopifyApp.configuration.api_key, 
-           ShopifyApp.configuration.secret,
+  provider :shopify,
+    ShopifyApp.configuration.api_key,
+    ShopifyApp.configuration.secret,
 
-           # Example permission scopes - see http://docs.shopify.com/api/tutorials/oauth for full listing
-           :scope => 'read_orders, read_products',
-
-           :setup => lambda {|env| 
-                       params = Rack::Utils.parse_query(env['QUERY_STRING'])
-                       site_url = "https://#{params['shop']}"
-                       env['omniauth.strategy'].options[:client_options][:site] = site_url
-                     }
+    # Example permission scopes - see http://docs.shopify.com/api/tutorials/oauth for full listing
+    scope: 'read_orders,read_products',
+    myshopify_domain: ShopifyApp.configuration.myshopify_domain || "myshopify.com",
+    setup: lambda {|env|
+             params = Rack::Utils.parse_query(env['QUERY_STRING'])
+             site_url = "https://#{params['shop']}"
+             env['omniauth.strategy'].options[:client_options][:site] = site_url
+           }
 end


### PR DESCRIPTION
@awd @jamesmacaulay @ilikeorangutans 
cc @haeky @garymardell @shawnfrench 

Uses feature introduced in shopify_app 5.0.2 https://github.com/Shopify/shopify_app/pull/121 to allow us to override the myshopify domain for this app by only adding an extra line to the `shopify_app.yml` file.

Does some simple clean ups for whitespace, quotes, and formatting at the same time.