### PR TITLE
Ensures myshopify_domain is properly set

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
 
   def sanitize_shop_param(params)
     return unless params[:shop].present?
-    return unless domain = ShopifyApp.configuration.myshopify_domain || "myshopify.com"
+    return unless domain = ShopifyApp.configuration.myshopify_domain.presence || "myshopify.com"
 
     name = params[:shop].to_s.strip
     name += ".#{domain}" if !name.include?(domain) && !name.include?(".")

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -5,7 +5,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
     # Example permission scopes - see http://docs.shopify.com/api/tutorials/oauth for full listing
     scope: 'read_orders,read_products',
-    myshopify_domain: ShopifyApp.configuration.myshopify_domain || "myshopify.com",
+    myshopify_domain: ShopifyApp.configuration.myshopify_domain.presence || "myshopify.com",
     setup: lambda {|env|
              params = Rack::Utils.parse_query(env['QUERY_STRING'])
              site_url = "https://#{params['shop']}"


### PR DESCRIPTION
Fixes #23 

#### Problem

Recently we allowed a custom `myshopify_domain` value to be set for easier internal development against our OAuth flow. `ShopifyApp` defaults to an empty string when an valid key is not explicitly set. `ShopifyApp.configuration.myshopify_domain` was an empty string, which was triggering a short circuit in the conditional logic flow.

#### Solution

Use `presence` on `ShopifyApp.configuration.myshopify_domain` to prevent an unintended short circuit. Presence will return the value if it is set, otherwise `nil`.

----
Please review: @kmcphillips @berkcaputcu 
CC: @craigmillr (this is the bug you had during hack days)